### PR TITLE
Exploit Unity 2017.3 support for 32bit indices

### DIFF
--- a/Assets/AsImpL/Scripts/Editor/ObjImportWindow.cs
+++ b/Assets/AsImpL/Scripts/Editor/ObjImportWindow.cs
@@ -168,7 +168,7 @@ namespace AsImpL
                 if (colliderConvex)
                 {
                     EditorGUILayout.HelpBox(
-                        "Building convex meshes may not work for meshes with too many smooth surface regions.\n"+
+                        "Building convex meshes may not work for meshes with too many smooth surface regions.\n" +
                         "If you get errors find each involved object and fix its mesh collider (e.g. remove it or uncheck \"Convex\").",
                         MessageType.Warning);
                     colliderTrigger = EditorGUILayout.Toggle("Mesh colliders as trigger", colliderTrigger);

--- a/Assets/AsImpL/Scripts/EditorUtil.cs
+++ b/Assets/AsImpL/Scripts/EditorUtil.cs
@@ -28,9 +28,13 @@ namespace AsImpL
         /// <param name="prefix">prefix at the beginning of the file name</param>
         public static void AutoCaptureScreenshot(string prefix)
         {
-            string fileName = prefix+"-"+DateTime.Now.ToString("s").Replace('T','_').Replace(':','-')+".png";
+            string fileName = prefix + "-" + DateTime.Now.ToString("s").Replace('T', '_').Replace(':', '-') + ".png";
+#if UNITY_2017_1_OR_NEWER
+            ScreenCapture.CaptureScreenshot(fileName);
+#else
             Application.CaptureScreenshot(fileName);
-            Debug.Log("Screenshot saved to " + Application.dataPath+"/" + fileName);
+#endif
+            Debug.Log("Screenshot saved to " + Application.dataPath + "/" + fileName);
             EditorUtility.RevealInFinder(Application.dataPath);
         }
 

--- a/Assets/AsImpL/Scripts/Loaders/LoaderObj.cs
+++ b/Assets/AsImpL/Scripts/Loaders/LoaderObj.cs
@@ -6,9 +6,6 @@ using System.Text.RegularExpressions;
 using System.IO;
 using System.Globalization;
 
-#if UNITY_EDITOR
-#endif
-
 namespace AsImpL
 {
     /// <summary>


### PR DESCRIPTION
Since Unity 2017.3 32 bit mesh index buffer format is supported. Index buffer can either be 16 bit (supports up to 65535 vertices in a mesh), or 32 bit (supports up to 4 billion vertices).
With this PR 32 bit indices are used only when really needed (more than 6K vertices), otherwise the old 16 bit format is used, since that takes less memory and bandwidth.
To make the code to work with different versions of Unity platform dependent compilation is used.
