### PR TITLE
Refactor filesystem access to allow extension

### DIFF
--- a/Assets/AsImpL/Scripts/IO.meta
+++ b/Assets/AsImpL/Scripts/IO.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b4f2254e567d40540b17ed7bb78df22a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AsImpL/Scripts/IO/FileFilesystem.cs
+++ b/Assets/AsImpL/Scripts/IO/FileFilesystem.cs
@@ -63,5 +63,75 @@ namespace AsImpL
             }
 #endif
         }
+
+        public IEnumerator DownloadTexture(string uri)
+        {
+#if UNITY_2018_3_OR_NEWER
+            using (UnityWebRequest uwr = UnityWebRequestTexture.GetTexture(uri))
+            {
+                yield return uwr.SendWebRequest();
+
+                if (uwr.isNetworkError || uwr.isHttpError)
+                {
+                    Debug.LogError(uwr.error);
+                }
+                else
+                {
+                    // Get downloaded asset bundle
+                    yield return DownloadHandlerTexture.GetContent(uwr);
+                }
+            }
+#else
+            WWW loader = new WWW(uri);
+            yield return loader;
+
+            if (loader.error != null)
+            {
+                Debug.LogError(loader.error);
+            }
+            else
+            {
+                yield return LoadTexture(loader);
+            }
+#endif
+        }
+
+#if !UNITY_2018_3_OR_NEWER
+        /// <summary>
+        /// Load a texture from the URL got from the parameter.
+        /// </summary>
+        private Texture2D LoadTexture(WWW loader)
+        {
+            string ext = Path.GetExtension(loader.url).ToLower();
+            Texture2D tex = null;
+
+            // TODO: add support for more formats (bmp, gif, dds, ...)
+            if (ext == ".tga")
+            {
+                tex = TextureLoader.LoadTextureFromUrl(loader.url);
+                //tex = TgaLoader.LoadTGA(new MemoryStream(loader.bytes));
+            }
+            else if (ext == ".png" || ext == ".jpg" || ext == ".jpeg")
+            {
+                tex = loader.texture;
+            }
+            else
+            {
+                Debug.LogWarning("Unsupported texture format: " + ext);
+            }
+
+            if (tex == null)
+            {
+                Debug.LogErrorFormat("Failed to load texture {0}", loader.url);
+            }
+            else
+            {
+                //tex.alphaIsTransparency = true;
+                //tex.filterMode = FilterMode.Trilinear;
+            }
+
+            return tex;
+        }
+#endif
     }
 }

--- a/Assets/AsImpL/Scripts/IO/FileFilesystem.cs
+++ b/Assets/AsImpL/Scripts/IO/FileFilesystem.cs
@@ -74,6 +74,7 @@ namespace AsImpL
                 if (uwr.isNetworkError || uwr.isHttpError)
                 {
                     Debug.LogError(uwr.error);
+                    yield return null;
                 }
                 else
                 {
@@ -88,6 +89,7 @@ namespace AsImpL
             if (loader.error != null)
             {
                 Debug.LogError(loader.error);
+                yield return null;
             }
             else
             {

--- a/Assets/AsImpL/Scripts/IO/FileFilesystem.cs
+++ b/Assets/AsImpL/Scripts/IO/FileFilesystem.cs
@@ -1,0 +1,67 @@
+using System.Collections;
+using System.IO;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace AsImpL
+{
+    /// <summary>
+    /// Filesystem implementation that uses the standard .NET File class.
+    /// </summary>
+    public class FileFilesystem : IFilesystem
+    {
+        public byte[] ReadAllBytes(string path)
+        {
+            return File.ReadAllBytes(path);
+        }
+
+        public string[] ReadAllLines(string path)
+        {
+            return File.ReadAllLines(path);
+        }
+
+        public FileStream OpenRead(string path)
+        {
+            return File.OpenRead(path);
+        }
+
+        public IEnumerator DownloadUri(string uri, bool notifyErrors)
+        {
+#if UNITY_2018_3_OR_NEWER
+            UnityWebRequest uwr = UnityWebRequest.Get(uri);
+            yield return uwr.SendWebRequest();
+
+            if (uwr.isNetworkError || uwr.isHttpError)
+            {
+                if (notifyErrors)
+                {
+                    Debug.LogError(uwr.error);
+                }
+
+                yield return null;
+            }
+            else
+            {
+                // Get downloaded asset bundle
+                yield return uwr.downloadHandler.text;
+            }
+#else
+            WWW www = new WWW(uri);
+            yield return www;
+            if (www.error != null)
+            {
+                if (notifyErrors)
+                {
+                    Debug.LogError("Error loading " + uri + "\n" + www.error);
+                }
+
+                yield return null;
+            }
+            else
+            {
+                yield return www.text;
+            }
+#endif
+        }
+    }
+}

--- a/Assets/AsImpL/Scripts/IO/FileFilesystem.cs.meta
+++ b/Assets/AsImpL/Scripts/IO/FileFilesystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56918d1d8d26c6b488ec48ff28fe0dd7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AsImpL/Scripts/IO/IFilesystem.cs
+++ b/Assets/AsImpL/Scripts/IO/IFilesystem.cs
@@ -34,7 +34,7 @@ namespace AsImpL
         /// </summary>
         /// <param name="uri">The URI to download.</param>
         /// <param name="notifyErrors">Whether to notify of errors.</param>
-        /// <returns>An enumrator usable as Coroutine in Unity.</returns>
+        /// <returns>An enumerator usable as Coroutine in Unity.</returns>
         IEnumerator DownloadUri(string uri, bool notifyErrors);
     }
 }

--- a/Assets/AsImpL/Scripts/IO/IFilesystem.cs
+++ b/Assets/AsImpL/Scripts/IO/IFilesystem.cs
@@ -36,5 +36,12 @@ namespace AsImpL
         /// <param name="notifyErrors">Whether to notify of errors.</param>
         /// <returns>An enumerator usable as Coroutine in Unity.</returns>
         IEnumerator DownloadUri(string uri, bool notifyErrors);
+
+        /// <summary>
+        /// Downloads the specified URI as texture.
+        /// </summary>
+        /// <param name="uri">The URI to download.</param>
+        /// <returns>An enumerator usable as Coroutine in Unity.</returns>
+        IEnumerator DownloadTexture(string uri);
     }
 }

--- a/Assets/AsImpL/Scripts/IO/IFilesystem.cs
+++ b/Assets/AsImpL/Scripts/IO/IFilesystem.cs
@@ -1,0 +1,40 @@
+using System.Collections;
+using System.IO;
+
+namespace AsImpL
+{
+    /// <summary>
+    /// Interface for classes that access the filesystem.
+    /// </summary>
+    public interface IFilesystem
+    {
+        /// <summary>
+        /// Reads all data from the specified path into a byte array.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        byte[] ReadAllBytes(string path);
+
+        /// <summary>
+        /// Reads all lines in the specified file into an array of strings.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        string[] ReadAllLines(string path);
+
+        /// <summary>
+        /// Opens the file at the specified path for reading.
+        /// </summary>
+        /// <param name="path"></param>
+        /// <returns></returns>
+        FileStream OpenRead(string path);
+
+        /// <summary>
+        /// Downloads the specified URI.
+        /// </summary>
+        /// <param name="uri">The URI to download.</param>
+        /// <param name="notifyErrors">Whether to notify of errors.</param>
+        /// <returns>An enumrator usable as Coroutine in Unity.</returns>
+        IEnumerator DownloadUri(string uri, bool notifyErrors);
+    }
+}

--- a/Assets/AsImpL/Scripts/IO/IFilesystem.cs.meta
+++ b/Assets/AsImpL/Scripts/IO/IFilesystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79a86b82a4f3ce7429ef221b36a9669e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AsImpL/Scripts/Loaders/Loader.cs
+++ b/Assets/AsImpL/Scripts/Loaders/Loader.cs
@@ -96,6 +96,25 @@ namespace AsImpL
             }
         }
 
+        private IFilesystem _filesystem = null;
+        public IFilesystem Filesystem
+        {
+            get
+            {
+                if (_filesystem is null)
+                {
+                    _filesystem = new FileFilesystem();
+                }
+
+                return _filesystem;
+            }
+
+            set
+            {
+                _filesystem = value;
+            }
+        }
+
 
         /// <summary>
         /// Check if a material library is defined for this model

--- a/Assets/AsImpL/Scripts/Loaders/Loader.cs
+++ b/Assets/AsImpL/Scripts/Loaders/Loader.cs
@@ -536,9 +536,10 @@ namespace AsImpL
 
             yield return enumerable;
 
-            enumerable.MoveNext();
-
-            loadedTexture = (Texture2D)enumerable.Current;
+            if (enumerable.Current != null)
+            {
+                loadedTexture = (Texture2D)enumerable.Current;
+            }
         }
 
 

--- a/Assets/AsImpL/Scripts/Loaders/Loader.cs
+++ b/Assets/AsImpL/Scripts/Loaders/Loader.cs
@@ -531,34 +531,14 @@ namespace AsImpL
         {
             loadedTexture = null;
             string texPath = GetTextureUrl(basePath, path);
-#if UNITY_2018_3_OR_NEWER
-            using (UnityWebRequest uwr = UnityWebRequestTexture.GetTexture(texPath))
-            {
-                yield return uwr.SendWebRequest();
 
-                if (uwr.isNetworkError || uwr.isHttpError)
-                {
-                    Debug.LogError(uwr.error);
-                }
-                else
-                {
-                    // Get downloaded asset bundle
-                    loadedTexture = DownloadHandlerTexture.GetContent(uwr);
-                }
-            }
-#else
-            WWW loader = new WWW(texPath);
-            yield return loader;
+            var enumerable = Filesystem.DownloadTexture(texPath);
 
-            if (loader.error != null)
-            {
-                Debug.LogError(loader.error);
-            }
-            else
-            {
-                loadedTexture = LoadTexture(loader);
-            }
-#endif
+            yield return enumerable;
+
+            enumerable.MoveNext();
+
+            loadedTexture = (Texture2D)enumerable.Current;
         }
 
 

--- a/Assets/AsImpL/Scripts/Loaders/LoaderObj.cs
+++ b/Assets/AsImpL/Scripts/Loaders/LoaderObj.cs
@@ -57,7 +57,7 @@ namespace AsImpL
             {
                 //mtlDepPathList.Add(mtlLibName);
                 string mtlPath = basePath + mtlLibName;
-                string[] lines = File.ReadAllLines(mtlPath);
+                string[] lines = Filesystem.ReadAllLines(mtlPath);
                 List<MaterialData> mtlData = new List<MaterialData>();
                 ParseMaterialData(lines, mtlData);
                 foreach (MaterialData mtl in mtlData)
@@ -370,7 +370,7 @@ namespace AsImpL
         /// <returns></returns>
         private string ParseMaterialLibName(string path)
         {
-            string[] lines = File.ReadAllLines(path);
+            string[] lines = Filesystem.ReadAllLines(path);
 
             objLoadingProgress.message = "Parsing geometry data...";
 
@@ -625,37 +625,13 @@ namespace AsImpL
         private IEnumerator LoadOrDownloadText(string url, bool notifyErrors = true)
         {
             loadedText = null;
-#if UNITY_2018_3_OR_NEWER
-            UnityWebRequest uwr = UnityWebRequest.Get(url);
-            yield return uwr.SendWebRequest();
 
-            if (uwr.isNetworkError || uwr.isHttpError)
-            {
-                if (notifyErrors)
-                {
-                    Debug.LogError(uwr.error);
-                }
-            }
-            else
-            {
-                // Get downloaded asset bundle
-                loadedText = uwr.downloadHandler.text;
-            }
-#else
-            WWW www = new WWW(url);
-            yield return www;
-            if (www.error != null)
-            {
-                if (notifyErrors)
-                {
-                    Debug.LogError("Error loading " + url + "\n" + www.error);
-                }
-            }
-            else
-            {
-                loadedText = www.text;
-            }
-#endif
+            var enumerable = Filesystem.DownloadUri(url, notifyErrors);
+
+            yield return enumerable;
+
+            enumerable.MoveNext();
+            loadedText = (string)enumerable.Current;
         }
 
 

--- a/Assets/AsImpL/Scripts/Loaders/LoaderObj.cs
+++ b/Assets/AsImpL/Scripts/Loaders/LoaderObj.cs
@@ -630,8 +630,10 @@ namespace AsImpL
 
             yield return enumerable;
 
-            enumerable.MoveNext();
-            loadedText = (string)enumerable.Current;
+            if (enumerable.Current != null)
+            {
+                loadedText = (string)enumerable.Current;
+            }
         }
 
 

--- a/Assets/AsImpL/Scripts/Loaders/TextureLoader.cs
+++ b/Assets/AsImpL/Scripts/Loaders/TextureLoader.cs
@@ -19,6 +19,25 @@ namespace AsImpL
     /// </remarks>
     public class TextureLoader : MonoBehaviour
     {
+        private static IFilesystem _filesystem = null;
+        public static IFilesystem Filesystem
+        {
+            get
+            {
+                if (_filesystem is null)
+                {
+                    _filesystem = new FileFilesystem();
+                }
+
+                return _filesystem;
+            }
+
+            set
+            {
+                _filesystem = value;
+            }
+        }
+
         /// <summary>
         /// Load an image from a file into a Texture2D.
         /// </summary>
@@ -50,7 +69,7 @@ namespace AsImpL
             if (ext == ".png" || ext == ".jpg")
             {
                 Texture2D t2d = new Texture2D(1, 1);
-                t2d.LoadImage(File.ReadAllBytes(fileName));
+                t2d.LoadImage(Filesystem.ReadAllBytes(fileName));
                 return t2d;
             }
             else if (ext == ".dds")
@@ -78,7 +97,7 @@ namespace AsImpL
         /// <returns>The loaded texture or null on error.</returns>
         public static Texture2D LoadTGA(string fileName)
         {
-            using (var imageFile = File.OpenRead(fileName))
+            using (var imageFile = Filesystem.OpenRead(fileName))
             {
                 return LoadTGA(imageFile);
             }
@@ -95,7 +114,7 @@ namespace AsImpL
             try
             {
 
-                byte[] ddsBytes = File.ReadAllBytes(ddsPath);
+                byte[] ddsBytes = Filesystem.ReadAllBytes(ddsPath);
 
                 byte ddsSizeCheck = ddsBytes[4];
                 if (ddsSizeCheck != 124)


### PR DESCRIPTION
This extracts an `IFilesystem` and a `FileFilesystem` using the current implementation.

I needed to be able to listen to filesystem and web access for debugging purposes as well as to collect what AsImpL is accessing during loading. Since everything uses static calls to the .NET and Unity APIs, this is currently impossible. Extension is not possible either because the methods are private (but would be a poor choice anyway).

Functionally this is the same as it was before.

I'm not too fond of introducing static properties, but I wanted to make these changes as minimally invasive as possible. The ideal solution would be constructor injection and non-static use, but I understand that this can be problematic with `MonoBehaviour`s in Unity, so this is the next best thing to have some extensibility, I guess.