### PR TITLE
Add package.json to allow installation through Unity project manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+	"name": "com.gpvigano.asimpl",
+	"displayName": "AsImpL",
+	"version": "1.0.0",
+	"description": "Asynchronous Importer and run-time Loader for Unity",
+	"unity": "5.5",
+	"unityRelease": "4",
+	"keywords": [
+		"unity",
+		"runtime",
+		"model",
+		"loader",
+		"obj"
+	],
+	"homepage": "https://github.com/gpvigano/AsImpL/",
+	"bugs": {
+		"url": "https://github.com/gpvigano/AsImpL/issues"
+	},
+	"repository": {
+		"type": "git",
+		"url": "ssh://git@github.com:gpvigano/AsImpL.git"
+	},
+	"license": "MIT"
+}


### PR DESCRIPTION
This adds a `package.json` so automatic installation through a Unity project's `manifest.json` becomes possible. The main advantage of this is that you can more easily update to newer (stable or unstable) versions of this library and it gets installed automatically in projects, i.e. you don't need to clutter your version control with code of dependencies.

More information on the settings can be found [here](https://docs.unity3d.com/2019.1/Documentation/Manual/upm-manifestPkg.html#unityRelease).

EDIT: Partially helps with #38.