### PR TITLE
Refactor shader and material selection to allow customizing shaders and materials

### DIFF
--- a/Assets/AsImpL/Scripts/Dataset/IMaterialFactory.cs
+++ b/Assets/AsImpL/Scripts/Dataset/IMaterialFactory.cs
@@ -1,0 +1,12 @@
+﻿using UnityEngine;
+
+namespace AsImpL
+{
+    /// <summary>
+    /// Interface for classes that create materials.
+    /// </summary>
+    public interface IMaterialFactory
+    {
+        Material Create(string shaderName);
+    }
+}

--- a/Assets/AsImpL/Scripts/Dataset/IMaterialFactory.cs.meta
+++ b/Assets/AsImpL/Scripts/Dataset/IMaterialFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72c40b3bf79821f18983ae2c8d50c71d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AsImpL/Scripts/Dataset/IShaderSelector.cs
+++ b/Assets/AsImpL/Scripts/Dataset/IShaderSelector.cs
@@ -5,6 +5,6 @@
     /// </summary>
     public interface IShaderSelector
     {
-        string Select(MaterialData md);
+        string Select(MaterialData md, bool useUnlit, ModelUtil.MtlBlendMode blendMode);
     }
 }

--- a/Assets/AsImpL/Scripts/Dataset/IShaderSelector.cs
+++ b/Assets/AsImpL/Scripts/Dataset/IShaderSelector.cs
@@ -1,0 +1,10 @@
+﻿namespace AsImpL
+{
+    /// <summary>
+    /// Interface for classes that select the shader to use based on the material data.
+    /// </summary>
+    public interface IShaderSelector
+    {
+        string Select(MaterialData md);
+    }
+}

--- a/Assets/AsImpL/Scripts/Dataset/IShaderSelector.cs.meta
+++ b/Assets/AsImpL/Scripts/Dataset/IShaderSelector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d7bb6a6dd153df4bbe3388fccaa2593
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AsImpL/Scripts/Dataset/MaterialFactory.cs
+++ b/Assets/AsImpL/Scripts/Dataset/MaterialFactory.cs
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+
+namespace AsImpL
+{
+    /// <summary>
+    /// Interface for classes that select the shader to use based on the material data.
+    /// </summary>
+    public class MaterialFactory : IMaterialFactory
+    {
+        /// <inheritdoc/>
+        public Material Create(string shaderName)
+        {
+            return new Material(Shader.Find(shaderName));
+        }
+    }
+}

--- a/Assets/AsImpL/Scripts/Dataset/MaterialFactory.cs.meta
+++ b/Assets/AsImpL/Scripts/Dataset/MaterialFactory.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4aabc90e9be8e4b60b751f8f3ffd299c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AsImpL/Scripts/Dataset/ObjectBuilder.cs
+++ b/Assets/AsImpL/Scripts/Dataset/ObjectBuilder.cs
@@ -43,42 +43,18 @@ namespace AsImpL
         // maximum number of vertices that can be used for triangles
         private static int MAX_VERT_COUNT = (MAX_VERTICES_LIMIT_FOR_A_MESH - 2) / 3 * 3;
 
-        private IShaderSelector _shaderSelector = null;
+        private IShaderSelector _shaderSelector;
         public IShaderSelector ShaderSelector
         {
-            get
-            {
-                if (_shaderSelector is null)
-                {
-                    _shaderSelector = new ShaderSelector();
-                }
-
-                return _shaderSelector;
-            }
-
-            set
-            {
-                _shaderSelector = value;
-            }
+            get => _shaderSelector ?? (_shaderSelector = new ShaderSelector());
+            set => _shaderSelector = value;
         }
 
-        private IMaterialFactory _materialFactory = null;
+        private IMaterialFactory _materialFactory;
         public IMaterialFactory MaterialFactory
         {
-            get
-            {
-                if (_materialFactory is null)
-                {
-                    _materialFactory = new MaterialFactory();
-                }
-
-                return _materialFactory;
-            }
-
-            set
-            {
-                _materialFactory = value;
-            }
+            get => _materialFactory ?? (_materialFactory = new MaterialFactory());
+            set => _materialFactory = value;
         }
 
         /// <summary>

--- a/Assets/AsImpL/Scripts/Dataset/ObjectBuilder.cs
+++ b/Assets/AsImpL/Scripts/Dataset/ObjectBuilder.cs
@@ -645,7 +645,6 @@ namespace AsImpL
         /// <returns>Unity material</returns>
         private Material BuildMaterial(MaterialData md)
         {
-            string shaderName = ShaderSelector.Select(md);
             bool specularMode = false;// (md.specularTex != null);
             ModelUtil.MtlBlendMode mode = md.overallAlpha < 1.0f ? ModelUtil.MtlBlendMode.TRANSPARENT : ModelUtil.MtlBlendMode.OPAQUE;
 
@@ -663,15 +662,7 @@ namespace AsImpL
                 diffuseIsTransparent = ModelUtil.ScanTransparentPixels(md.diffuseTex, ref mode);
             }
 
-            if (useUnlit && !diffuseIsTransparent.Value)
-            {
-                shaderName = "Unlit/Texture";
-            }
-            else if (specularMode)
-            {
-                shaderName = "Standard (Specular setup)";
-            }
-            Material newMaterial = new Material(Shader.Find(shaderName)); // "Standard (Specular setup)"
+            Material newMaterial = new Material(Shader.Find(ShaderSelector.Select(md, useUnlit, mode))); // "Standard (Specular setup)"
             newMaterial.name = md.materialName;
 
             float shinLog = Mathf.Log(md.shininess, 2);

--- a/Assets/AsImpL/Scripts/Dataset/ObjectBuilder.cs
+++ b/Assets/AsImpL/Scripts/Dataset/ObjectBuilder.cs
@@ -43,6 +43,24 @@ namespace AsImpL
         // maximum number of vertices that can be used for triangles
         private static int MAX_VERT_COUNT = (MAX_VERTICES_LIMIT_FOR_A_MESH - 2) / 3 * 3;
 
+        private IShaderSelector _shaderSelector = null;
+        public IShaderSelector ShaderSelector
+        {
+            get
+            {
+                if (_shaderSelector is null)
+                {
+                    _shaderSelector = new ShaderSelector();
+                }
+
+                return _shaderSelector;
+            }
+
+            set
+            {
+                _shaderSelector = value;
+            }
+        }
 
         /// <summary>
         /// Initialize the importing of materials
@@ -627,7 +645,7 @@ namespace AsImpL
         /// <returns>Unity material</returns>
         private Material BuildMaterial(MaterialData md)
         {
-            string shaderName = "Standard";// (md.illumType == 2) ? "Standard (Specular setup)" : "Standard";
+            string shaderName = ShaderSelector.Select(md);
             bool specularMode = false;// (md.specularTex != null);
             ModelUtil.MtlBlendMode mode = md.overallAlpha < 1.0f ? ModelUtil.MtlBlendMode.TRANSPARENT : ModelUtil.MtlBlendMode.OPAQUE;
 

--- a/Assets/AsImpL/Scripts/Dataset/ObjectBuilder.cs
+++ b/Assets/AsImpL/Scripts/Dataset/ObjectBuilder.cs
@@ -62,6 +62,25 @@ namespace AsImpL
             }
         }
 
+        private IMaterialFactory _materialFactory = null;
+        public IMaterialFactory MaterialFactory
+        {
+            get
+            {
+                if (_materialFactory is null)
+                {
+                    _materialFactory = new MaterialFactory();
+                }
+
+                return _materialFactory;
+            }
+
+            set
+            {
+                _materialFactory = value;
+            }
+        }
+
         /// <summary>
         /// Initialize the importing of materials
         /// </summary>
@@ -87,7 +106,7 @@ namespace AsImpL
                 {
                     Debug.LogWarning("No material library defined. Using a default material.");
                 }
-                currMaterials.Add("default", new Material(Shader.Find(shaderName)));
+                currMaterials.Add("default", MaterialFactory.Create(shaderName));
             }
         }
 
@@ -662,7 +681,7 @@ namespace AsImpL
                 diffuseIsTransparent = ModelUtil.ScanTransparentPixels(md.diffuseTex, ref mode);
             }
 
-            Material newMaterial = new Material(Shader.Find(ShaderSelector.Select(md, useUnlit, mode))); // "Standard (Specular setup)"
+            Material newMaterial = MaterialFactory.Create(ShaderSelector.Select(md, useUnlit, mode)); // "Standard (Specular setup)"
             newMaterial.name = md.materialName;
 
             float shinLog = Mathf.Log(md.shininess, 2);

--- a/Assets/AsImpL/Scripts/Dataset/ShaderSelector.cs
+++ b/Assets/AsImpL/Scripts/Dataset/ShaderSelector.cs
@@ -13,9 +13,27 @@
         }
 
         /// <inheritdoc/>
-        public string Select(MaterialData md)
+        public string Select(MaterialData md, bool useUnlit, ModelUtil.MtlBlendMode blendMode)
         {
-            return defaultShader;// (md.illumType == 2) ? "Standard (Specular setup)" : defaultShader;
+            const bool specularMode = false;// (md.specularTex != null);
+
+            bool? diffuseIsTransparent = null;
+            if (useUnlit)
+            {
+                // do not use unlit shader if the texture has transparent pixels
+                diffuseIsTransparent = ModelUtil.ScanTransparentPixels(md.diffuseTex, ref blendMode);
+            }
+
+            if (useUnlit && !diffuseIsTransparent.Value)
+            {
+                return "Unlit/Texture";
+            }
+            else if (specularMode)
+            {
+                return "Standard (Specular setup)";
+            }
+
+            return defaultShader; // (md.illumType == 2) ? "Standard (Specular setup)" : defaultShader
         }
     }
 }

--- a/Assets/AsImpL/Scripts/Dataset/ShaderSelector.cs
+++ b/Assets/AsImpL/Scripts/Dataset/ShaderSelector.cs
@@ -1,0 +1,21 @@
+﻿namespace AsImpL
+{
+    /// <summary>
+    /// Interface for classes that select the shader to use based on the material data.
+    /// </summary>
+    public class ShaderSelector : IShaderSelector
+    {
+        private readonly string defaultShader;
+
+        public ShaderSelector(string defaultShader = "Standard")
+        {
+            this.defaultShader = defaultShader;
+        }
+
+        /// <inheritdoc/>
+        public string Select(MaterialData md)
+        {
+            return defaultShader;// (md.illumType == 2) ? "Standard (Specular setup)" : defaultShader;
+        }
+    }
+}

--- a/Assets/AsImpL/Scripts/Dataset/ShaderSelector.cs.meta
+++ b/Assets/AsImpL/Scripts/Dataset/ShaderSelector.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 73f70be058a983bdfb31daa3caad5069
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AsImpL/Scripts/Loaders/Loader.cs
+++ b/Assets/AsImpL/Scripts/Loaders/Loader.cs
@@ -47,7 +47,12 @@ namespace AsImpL
         protected static Dictionary<string, int> instanceCount = new Dictionary<string, int>();
 
         protected DataSet dataSet = new DataSet();
-        protected ObjectBuilder objectBuilder = new ObjectBuilder();
+        protected ObjectBuilder _objectBuilder;
+        public ObjectBuilder ObjectBuilder
+        {
+            get => _objectBuilder ?? (_objectBuilder = new ObjectBuilder());
+            set => _objectBuilder = value;
+        }
 
         protected List<MaterialData> materialData;
 
@@ -335,18 +340,18 @@ namespace AsImpL
             objLoadingProgress.message = "Loading materials...";
             yield return null;
 #if UNITY_EDITOR
-            objectBuilder.alternativeTexPath = altTexPath;
+            ObjectBuilder.alternativeTexPath = altTexPath;
 #endif
-            objectBuilder.buildOptions = buildOptions;
+            ObjectBuilder.buildOptions = buildOptions;
             bool hasColors = dataSet.colorList.Count > 0;
             bool hasMaterials = materialData != null;
-            objectBuilder.InitBuildMaterials(materialData, hasColors);
+            ObjectBuilder.InitBuildMaterials(materialData, hasColors);
             float objInitPerc = objLoadingProgress.percentage;
             if (hasMaterials)
             {
-                while (objectBuilder.BuildMaterials(info))
+                while (ObjectBuilder.BuildMaterials(info))
                 {
-                    objLoadingProgress.percentage = objInitPerc + MATERIAL_PHASE_PERC * objectBuilder.NumImportedMaterials / materialData.Count;
+                    objLoadingProgress.percentage = objInitPerc + MATERIAL_PHASE_PERC * ObjectBuilder.NumImportedMaterials / materialData.Count;
                     yield return null;
                 }
                 loadStats.buildStats.materialsTime = Time.realtimeSinceStartup - prevTime;
@@ -364,8 +369,8 @@ namespace AsImpL
             OnCreated(newObj, absolutePath);
             ////newObj.transform.localScale = Vector3.one * Scaling;
             float initProgress = objLoadingProgress.percentage;
-            objectBuilder.StartBuildObjectAsync(dataSet, newObj);
-            while (objectBuilder.BuildObjectAsync(ref info))
+            ObjectBuilder.StartBuildObjectAsync(dataSet, newObj);
+            while (ObjectBuilder.BuildObjectAsync(ref info))
             {
                 objLoadingProgress.message = "Building scene objects... " + (info.objectsLoaded + info.groupsLoaded) + "/" + (dataSet.objectList.Count + info.numGroups);
                 objLoadingProgress.percentage = initProgress + BUILD_PHASE_PERC * (info.objectsLoaded / dataSet.objectList.Count + (float)info.groupsLoaded / info.numGroups);


### PR DESCRIPTION
This refactors the `ObjectBuilder` a bit to use a separate object to select what shader to use and another one to create new materials. BC is maintained by using a default implementation that has the old behavior.

The `Loader` was also modified to allow touching the `ObjectBuilder` object, or injecting your own, without which you would not be able to configure this new `ShaderSelector` or `MaterialFactory` property anywhere easily.

The reasoning for this is that we are using the [MRTK](https://github.com/microsoft/MixedRealityToolkit-Unity), which has [its own shader](https://docs.microsoft.com/en-us/windows/mixed-reality/mrtk-unity/features/rendering/mrtk-standard-shader) that is optimized for mixed reality devices, and we want to use this instead of the default Unity shader.

Configuring the material factory is useful if you want to clone an existing material from somewhere, load one from the resources folder instead, or do some other custom logic.